### PR TITLE
Run tests on CI

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install numpy nibabel>=2.2 six nose coverage
+git clone https://github.com/demianw/nibabel-nitest-cifti2.git
+mv nibabel-nitest-cifti2 nitest-cifti2

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export NIBABEL_DATA_DIR=`pwd`
+
+nosetests --with-coverage --cover-package=cifti --where=cifti

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+branches:
+  only:
+    - master
+
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+services:
+  - docker
+
+install:
+  - "pip install numpy nibabel>=2.2 six pytest pytest-runner coverage"
+
+script:
+  - pytest --cov=cifti

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 install:
-  - "pip install numpy nibabel>=2.2 six nose coverage"
+  - ./.ci/install.sh
 
 script:
-  - nosetests --with-coverage --cover-package=cifti --where=cifti
+  - ./.ci/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 install:
-  - "pip install numpy nibabel>=2.2 six pytest pytest-runner coverage"
+  - "pip install numpy nibabel>=2.2 six nose coverage"
 
 script:
-  - pytest --cov=cifti
+  - nosetests --with-coverage --cover-package=cifti --where=cifti

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='cifti',
       version='1.0',


### PR DESCRIPTION
This PR proposes a handful of "administrative" updates to `cifti`:

 - `.travis-ci.yml`: Run unit tests against differen versions of Python on each push.
 - Add a `MANIFEST` file so `sdist` tarballs can be built
 - Use `setuptools` instead of `distutils` - `distutils` does not actually understand the `install_requires` dependency argument.

If you would like, I am happy to follow this up with another PR that will use travis to [automatically deploy](https://docs.travis-ci.com/user/deployment/pypi/#Deploying-tags) `cifti` to  PyPI on each tag. 